### PR TITLE
prototype of spatial image display for SpotWhisperer

### DIFF
--- a/client/src/components/graph/drawPointsRegl.js
+++ b/client/src/components/graph/drawPointsRegl.js
@@ -39,6 +39,8 @@ export default function drawPointsRegl(regl) {
 
       float alpha = isBackground ? 0.9 : 1.0;
       fragColor = vec4(color, alpha);
+      // Make more trasparent for spatial to see image.
+      // fragColor = vec4(color, 0.8);
     }`,
 
     frag: `

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -759,7 +759,6 @@ class Graph extends React.Component {
       camera,
       projectionTF,
     } = this.state;
-    console.log("RENDER CANVAS CALL NOW!")
     // Clear the depth buffer to ensure we can render both the image and points correctly
     /* regl.clear({
       color: [1, 0, 0, 1],
@@ -801,7 +800,6 @@ class Graph extends React.Component {
       flagBuffer({ data: flags, dimension: 1 });
       needToRenderCanvas = true;
     }
-    if (needToRenderCanvas) console.log("NEED TO RENDER CANVAS");
     if (needToRenderCanvas) this.renderCanvas();
   }
 
@@ -843,7 +841,6 @@ class Graph extends React.Component {
       camera,
       projectionTF,
     ) {
-    console.log("RENDER IMAGE CALL NOW!");
     const cameraTF = camera.view();
     const projView = mat3.multiply(mat3.create(), projectionTF, cameraTF);
     if (this.texture) {
@@ -918,7 +915,6 @@ class Graph extends React.Component {
     camera,
     projectionTF
   ) {
-    console.log("RENDER POINTS CALL NOW");
     const { annoMatrix } = this.props;
     if (!this.reglCanvas || !annoMatrix) return;
 

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -255,8 +255,11 @@ class Graph extends React.Component {
 
   // Create image URL based on width and height
   createImageUrl(width, height) {
-    // larger scale factors may cause the image request to timeout resulting
-    // in no image being shown. Use Chrome Dev Tools to check requests.
+    // the `scale_factor` parameter controls the amount of downsampling that is performed server-side
+    // before the image is sent to the browser. For h5ad files which contain an image which is not 
+    // suitably downsampled this could result in sending a very large file and lead to the network request
+    // timing out. In future some adaptive use of this parameter can be used to get the best resolution image
+    // for a given display scenario. To debug use Chrome Dev Tools to check requests.
     return globals.API.prefix + globals.API.version + `spatial/image?view_x=${width}&view_y=${height}&scale_factor=1`;
   }
 

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -5,7 +5,7 @@ import { mat3, vec2 } from "gl-matrix";
 import _regl from "regl";
 import memoize from "memoize-one";
 import Async from "react-async";
-import { Button } from "@blueprintjs/core";
+import { Button, NonIdealState } from "@blueprintjs/core";
 
 import setupSVGandBrushElements from "./setupSVGandBrush";
 import _camera from "../../util/camera";
@@ -214,11 +214,13 @@ class Graph extends React.Component {
     this.reglCanvas = null;
     this.cachedAsyncProps = null;
     const modelTF = createModelTF();
+    this.texture = null; // Initialize texture
     this.state = {
       toolSVG: null,
       tool: null,
       container: null,
       viewport,
+      imageUrl: this.createImageUrl(viewport.width, viewport.height),
 
       // projection
       camera: null,
@@ -251,9 +253,48 @@ class Graph extends React.Component {
     };
   }
 
+  // Create image URL based on width and height
+  createImageUrl(width, height) {
+    // larger scale factors may cause the image request to timeout resulting
+    // in no image being shown. Use Chrome Dev Tools to check requests.
+    return globals.API.prefix + globals.API.version + `spatial/image?view_x=${width}&view_y=${height}&scale_factor=1`;
+  }
+
   componentDidMount() {
     window.addEventListener("resize", this.handleResize);
+    this.imgElement = document.getElementById('hande');
+    this.imgElement.onload = this.handleImageLoad; // Add this line
   }
+
+  handleImageLoad = () => {
+    // Check if the regl instance and imgElement are available
+    if (this.state.regl && this.imgElement) {
+      if (this.texture) {
+        this.texture(this.imgElement); // Update existing texture
+      } else {
+        this.texture = this.state.regl.texture(this.imgElement); // Create texture if it doesn't exist
+      }
+    }
+    console.log("Force redraw of image now!")
+    /*regl.clear({
+      color: [1, 1, 1, 1],
+      //depth: 1
+    });*/
+    /*
+    this.renderImage(
+      regl, camera, projectionTF
+    );
+    this.renderPoints(
+      regl,
+      drawPoints,
+      colorBuffer,
+      pointBuffer,
+      flagBuffer,
+      camera,
+      projectionTF
+    ); */
+    this.renderCanvas(); // redraw everything else.
+  };
 
   componentDidUpdate(prevProps, prevState) {
     const { selectionTool, currentSelection, graphInteractionMode } =
@@ -295,10 +336,21 @@ class Graph extends React.Component {
       // eslint-disable-next-line react/no-did-update-set-state --- Preventing update loop via stateChanges and diff checks
       this.setState(stateChanges);
     }
+
+    // Update image URL if width or height changes
+    if (prevState.viewport.width !== viewport.width || prevState.viewport.height !== viewport.height) {
+      this.setState({
+        imageUrl: this.createImageUrl(viewport.width, viewport.height),
+      });
+    }
   }
 
   componentWillUnmount() {
     window.removeEventListener("resize", this.handleResize);
+    // Clean up texture if necessary
+    if (this.texture) {
+      this.texture.destroy(); // Or any necessary cleanup depending on your REG-GL wrapper
+    }
   }
 
   handleResize = () => {
@@ -722,6 +774,15 @@ class Graph extends React.Component {
       camera,
       projectionTF,
     } = this.state;
+    console.log("RENDER CANVAS CALL NOW!")
+    // Clear the depth buffer to ensure we can render both the image and points correctly
+    /* regl.clear({
+      color: [1, 0, 0, 1],
+      depth: -1,
+    }); */
+    this.renderImage(
+      regl, camera, projectionTF
+    );
     this.renderPoints(
       regl,
       drawPoints,
@@ -731,6 +792,7 @@ class Graph extends React.Component {
       camera,
       projectionTF
     );
+    
   });
 
   updateReglAndRender(asyncProps, prevAsyncProps) {
@@ -754,6 +816,7 @@ class Graph extends React.Component {
       flagBuffer({ data: flags, dimension: 1 });
       needToRenderCanvas = true;
     }
+    if (needToRenderCanvas) console.log("NEED TO RENDER CANVAS");
     if (needToRenderCanvas) this.renderCanvas();
   }
 
@@ -790,6 +853,77 @@ class Graph extends React.Component {
     return createColorQuery(colorMode, colorAccessor, schema, genesets);
   }
 
+  renderImage(
+      regl,
+      camera,
+      projectionTF,
+    ) {
+    console.log("RENDER IMAGE CALL NOW!");
+    const cameraTF = camera.view();
+    const projView = mat3.multiply(mat3.create(), projectionTF, cameraTF);
+    if (this.texture) {
+
+      regl.poll();
+      regl({
+
+        // In a draw call, we can pass the shader source code to regl
+        frag: `
+        precision mediump float;
+        uniform vec4 color;
+        uniform vec2 position;
+
+        //***
+        uniform sampler2D texture;
+        varying vec2 uv;
+        //***
+
+        void main () {
+          //gl_FragColor = vec4(mod(gl_FragCoord.x, 2), 1, 1, 1); //color;
+          //gl_FragColor = color;
+          //uv = position;
+          vec2 invertedUV = vec2(uv.x, 1.0 - uv.y); // Flip the v coordinate
+          gl_FragColor = texture2D(texture, uv); //invertedUV);
+        }`,
+
+        vert: `
+        precision mediump float;
+        attribute vec2 position;
+        uniform float z;
+
+        //***
+        varying vec2 uv;
+        uniform mat3 projView;
+        //***
+
+        void main () {
+          vec3 xy = projView * vec3(position, 1.);
+          gl_Position = vec4(xy.xy, z, 1.);
+          uv = (position + 1.0) * 0.5; // Convert position (-1, 1) to (0, 1)
+          // gl_Position = vec4(position, 0, 1);
+        }`,
+
+        attributes: {
+          position: [
+            [-1, -1],
+            [1, -1],
+            [1, 1],
+            [-1, 1]
+          ]
+        },
+
+        uniforms: {
+          color: [0, 1, 0, 1],
+          texture: this.texture, //regl.texture(document.getElementById('hande')),
+          projView: projView,
+          z: 0.99, // 0.99 is background, see drawPointsRegl.js
+        },
+        primitive: 'triangle fan',
+        count: 4
+      })()
+      regl._gl.flush();
+    }
+  }
+
   renderPoints(
     regl,
     drawPoints,
@@ -799,6 +933,7 @@ class Graph extends React.Component {
     camera,
     projectionTF
   ) {
+    console.log("RENDER POINTS CALL NOW");
     const { annoMatrix } = this.props;
     if (!this.reglCanvas || !annoMatrix) return;
 
@@ -807,10 +942,10 @@ class Graph extends React.Component {
     const projView = mat3.multiply(mat3.create(), projectionTF, cameraTF);
     const { width, height } = this.reglCanvas;
     regl.poll();
-    regl.clear({
+    /*regl.clear({
       depth: 1,
       color: [1, 1, 1, 1],
-    });
+    }); */
     drawPoints({
       distance: camera.distance(),
       color: colorBuffer,
@@ -833,7 +968,7 @@ class Graph extends React.Component {
       pointDilation,
       crossfilter,
     } = this.props;
-    const { modelTF, projectionTF, camera, viewport, regl } = this.state;
+    const { modelTF, projectionTF, camera, viewport, imageUrl, regl } = this.state;
     const cameraTF = camera?.view()?.slice();
 
     return (
@@ -891,7 +1026,7 @@ class Graph extends React.Component {
           onDoubleClick={this.handleCanvasEvent}
           onWheel={this.handleCanvasEvent}
         />
-
+        <img id="hande" crossOrigin="" style={{display: 'none' }} src={imageUrl} onLoad={this.handleImageLoad}></img>
         <Async
           watchFn={Graph.watchAsync}
           promiseFn={this.fetchAsyncProps}

--- a/client/src/components/graph/graph.js
+++ b/client/src/components/graph/graph.js
@@ -265,7 +265,7 @@ class Graph extends React.Component {
 
   componentDidMount() {
     window.addEventListener("resize", this.handleResize);
-    this.imgElement = document.getElementById('hande');
+    this.imgElement = document.getElementById('h_and_e');
     this.imgElement.onload = this.handleImageLoad; // Add this line
   }
 
@@ -278,24 +278,6 @@ class Graph extends React.Component {
         this.texture = this.state.regl.texture(this.imgElement); // Create texture if it doesn't exist
       }
     }
-    console.log("Force redraw of image now!")
-    /*regl.clear({
-      color: [1, 1, 1, 1],
-      //depth: 1
-    });*/
-    /*
-    this.renderImage(
-      regl, camera, projectionTF
-    );
-    this.renderPoints(
-      regl,
-      drawPoints,
-      colorBuffer,
-      pointBuffer,
-      flagBuffer,
-      camera,
-      projectionTF
-    ); */
     this.renderCanvas(); // redraw everything else.
   };
 
@@ -916,7 +898,7 @@ class Graph extends React.Component {
 
         uniforms: {
           color: [0, 1, 0, 1],
-          texture: this.texture, //regl.texture(document.getElementById('hande')),
+          texture: this.texture, //regl.texture(document.getElementById('h_and_e')),
           projView: projView,
           z: 0.99, // 0.99 is background, see drawPointsRegl.js
         },
@@ -1029,7 +1011,7 @@ class Graph extends React.Component {
           onDoubleClick={this.handleCanvasEvent}
           onWheel={this.handleCanvasEvent}
         />
-        <img id="hande" crossOrigin="" style={{display: 'none' }} src={imageUrl} onLoad={this.handleImageLoad}></img>
+        <img id="h_and_e" crossOrigin="" style={{display: 'none' }} src={imageUrl} onLoad={this.handleImageLoad}></img>
         <Async
           watchFn={Graph.watchAsync}
           promiseFn={this.fetchAsyncProps}

--- a/client/src/globals.js
+++ b/client/src/globals.js
@@ -117,8 +117,7 @@ if (typeof window !== "undefined" && window.CELLXGENE && window.CELLXGENE.API) {
     // prefix: "http://api-staging.clustering.czi.technology/api/",
     // prefix: `http://s0-n11.hpc.meduniwien.ac.at:${CXG_SERVER_PORT}/api/`,
     // prefix: `http://localhost:${CXG_SERVER_PORT}/api/`,
-    // prefix: `https://cellwhisperer.cemm.at/colonic_epithelium/api/`,
-    prefix: `http://d014.int.cemm.at:5005/api/`,
+    prefix: `https://cellwhisperer.cemm.at/colonic_epithelium/api/`,
     version: "v0.2/",
   };
 }

--- a/client/src/globals.js
+++ b/client/src/globals.js
@@ -117,7 +117,8 @@ if (typeof window !== "undefined" && window.CELLXGENE && window.CELLXGENE.API) {
     // prefix: "http://api-staging.clustering.czi.technology/api/",
     // prefix: `http://s0-n11.hpc.meduniwien.ac.at:${CXG_SERVER_PORT}/api/`,
     // prefix: `http://localhost:${CXG_SERVER_PORT}/api/`,
-    prefix: `https://cellwhisperer.cemm.at/colonic_epithelium/api/`,
+    // prefix: `https://cellwhisperer.cemm.at/colonic_epithelium/api/`,
+    prefix: `http://d014.int.cemm.at:5005/api/`,
     version: "v0.2/",
   };
 }

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -210,7 +210,7 @@ class SpatialImageAPI(Resource):
     @cache_control(no_store=True)
     @rest_get_data_adaptor
     def get(self, data_adaptor):
-        return common_rest.get_image_spatial(request, data_adaptor)
+        return common_rest.spatial_image_get(request, data_adaptor)
 
 class GenesetsAPI(Resource):
     @cache_control(public=True, max_age=ONE_WEEK)

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -206,6 +206,11 @@ class LLMEmbeddingsInterpretationAPI(Resource):
     def post(self, data_adaptor):
         return common_rest.llm_embeddings_gene_contributions_post(request, data_adaptor)
 
+class SpatialImageAPI(Resource):
+    @cache_control(no_store=True)
+    @rest_get_data_adaptor
+    def get(self, data_adaptor):
+        return common_rest.get_image_spatial(request, data_adaptor)
 
 class GenesetsAPI(Resource):
     @cache_control(public=True, max_age=ONE_WEEK)
@@ -257,6 +262,7 @@ def get_api_dataroot_resources(bp_dataroot):
     add_resource(DataVarAPI, "/data/var")
     add_resource(GenesetsAPI, "/genesets")
     add_resource(SummarizeVarAPI, "/summarize/var")
+    add_resource(SpatialImageAPI, "/spatial/image")
     # Display routes
     add_resource(ColorsAPI, "/colors")
     # Computation routes

--- a/server/common/rest.py
+++ b/server/common/rest.py
@@ -30,7 +30,7 @@ from server.common.errors import (
 from server.common.genesets import summarizeQueryHash
 from server.common.fbs.matrix import decode_matrix_fbs
 
-def get_image_spatial(request, data_adaptor):
+def spatial_image_get(request, data_adaptor):
     try:
         image_data = data_adaptor.get_image_data()
     except KeyError: # No image data in slot.

--- a/server/data_anndata/anndata_adaptor.py
+++ b/server/data_anndata/anndata_adaptor.py
@@ -20,6 +20,8 @@ from server.common.utils.type_conversion_utils import get_schema_type_hint_of_ar
 from server.data_common.data_adaptor import DataAdaptor
 from server.common.fbs.matrix import encode_matrix_fbs
 
+# Update when factoring out 20x slide to next level.
+import math
 
 anndata_version = version.parse(str(anndata.__version__)).release
 
@@ -458,7 +460,13 @@ class AnndataAdaptor(DataAdaptor):
     def get_obs_keys(self):
         # return list of keys
         return self.data.obs.keys().to_list()
-
+    
+    def get_image_data(self):
+        return self.data.uns['20x_slide']
+    
+    def get_spatial_extent(self):
+        return self.data.uns["image_extents"]
+    
     def get_var_keys(self):
         # return list of keys
         return self.data.var.keys().to_list()

--- a/server/data_common/data_adaptor.py
+++ b/server/data_common/data_adaptor.py
@@ -400,7 +400,15 @@ class DataAdaptor(metaclass=ABCMeta):
         with ServerTiming.time("layout.query"):
             for ename in embeddings:
                 embedding = self.get_embedding_array(ename, 2)
-                normalized_layout = DataAdaptor.normalize_embedding(embedding)
+                # If this is a spatial dataset, the scaling needs to be to pixel space, not point space.
+                print("NAME IS WHAT: ", ename)
+                if ename == "spatial":
+                    print(self.get_spatial_extent())
+                    normalized_layout = embedding / self.get_spatial_extent()
+                    
+                    normalized_layout = normalized_layout.astype(dtype=np.float32)
+                else:
+                    normalized_layout = DataAdaptor.normalize_embedding(embedding)
                 layout_data.append(pd.DataFrame(normalized_layout, columns=[f"{ename}_0", f"{ename}_1"]))
 
         with ServerTiming.time("layout.encode"):

--- a/server/data_common/data_adaptor.py
+++ b/server/data_common/data_adaptor.py
@@ -401,7 +401,6 @@ class DataAdaptor(metaclass=ABCMeta):
             for ename in embeddings:
                 embedding = self.get_embedding_array(ename, 2)
                 # If this is a spatial dataset, the scaling needs to be to pixel space, not point space.
-                print("NAME IS WHAT: ", ename)
                 if ename == "spatial":
                     print(self.get_spatial_extent())
                     normalized_layout = embedding / self.get_spatial_extent()


### PR DESCRIPTION
linked issue [#597](https://github.com/epigen/cellwhisperer_private/issues/597)

Will need to be refactored. At the moment makes a mess of the data adapter classes (with no error handling per-se). Dependencies on metadata included in the anndata object need to be incorporated into the processing pipeline.

- Before being downsampled (to reduce load times) the original image space dimensions need to be recorded.
```
image_data = adata.uns['20x_slide']
extent_x = image_data.shape[0] * 2
extent_y = image_data.shape[1] * 2
adata.uns["image_extents"] = np.array([extent_x, extent_y])
```
- The 20x_slide needs to be downsampled for a initial viewpoint size of ~500.
